### PR TITLE
fix: 解决管理员面板和 App ID 搜索中的崩溃问题

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -344,7 +344,7 @@ class AdminPanelHandler:
             text = f"{status_message}\n\n" + text
         # 修正排序与展示
         text += (
-            foldable_text_v2("\n".join([f"• `{a['user_id']}`" for a in sorted(admins, key=lambda a: a["user_id"])]))
+            "\n".join([f"• `{a['user_id']}`" for a in sorted(admins, key=lambda a: a["user_id"])])
             if admins
             else "📭 暂无管理员"
         )

--- a/commands/app_store.py
+++ b/commands/app_store.py
@@ -944,7 +944,6 @@ async def handle_app_id_query(update: Update, context: ContextTypes.DEFAULT_TYPE
         logger.info(f"缓存应用详情: App ID {app_id}, 国家: {countries_hash}")
 
         # 生成会话ID用于消息管理
-        import time
         session_id = f"app_id_query_{user_id}_{int(time.time())}"
         
         # 删除搜索进度消息，然后发送结果


### PR DESCRIPTION
**1. 修复管理员面板的 Markdown 解析错误**
- **问题**： 当管理员在管理面板中点击“管理管理员”按钮时，机器人会因为 BadRequest: Can't parse entities 错误而崩溃。
- **原因**： 这是由于 show_admin_panel 函数中的双重格式化问题导致的，消息内容被文本格式化工具处理了两次，生成了无效的 Markdown。
- **解决方案**： 移除了多余的格式化调用，现在“管理管理员”面板可以正常显示。

**2. 解决 App ID 搜索功能的崩溃问题**
- **问题**： 直接使用 App ID 进行搜索（例如 /app id...）时，程序会因为 UnboundLocalError 错误而崩溃。
- **原因**： 这是由于 handle_app_id_query 函数内部一个错位的 import time 语句导致的，它与 Python 的变量作用域规则冲突。
- **解决方案**： 移除了函数内部的 import 语句，使其能够正确使用全局导入的 time 模块，恢复了 App ID 查询功能。